### PR TITLE
Handle game's court selection to move the game to a court.

### DIFF
--- a/vueapp/src/components/OnDeck.vue
+++ b/vueapp/src/components/OnDeck.vue
@@ -10,12 +10,9 @@
           @start="isDragging = true"
           @end="isDragging = false"
         >
-          <template #item="{ element, index }">
+          <template #item="{ element }">
             <div class="d-flex mb-3">
-              <Game
-                :game="element"
-                :gameIndex="index"
-              ></Game>
+              <Game :game="element"></Game>
             </div>
           </template>
         </draggable>
@@ -36,5 +33,5 @@ import draggable from "vuedraggable";
 const gameStore = useGameStore();
 const dragOptions = {
   animation: 100,
-}
+};
 </script>

--- a/vueapp/src/stores/gameStore.ts
+++ b/vueapp/src/stores/gameStore.ts
@@ -29,14 +29,14 @@ export const useGameStore = defineStore(GAMES_ON_DECK_STORE_ID, {
       }
     },
     // Remove the game at the given index and return all players in the game to the waiting queue
-    removeGameAt(index: number) {
+    removeFromOnDeck(game: Game) {
+      var index = this.gamesOnDeck.indexOf(game)
       if (index > -1) {
-        var game = this.gamesOnDeck[index]
-        this.gamesOnDeck.splice(index, 1);
         var playerStore = usePlayerStore();
         game.players.forEach(player => {
           playerStore.addPlayer(player)
         });
+        this.gamesOnDeck.splice(index, 1);
       }
     },
     addGameToOnDeckQueue(game: Game) {


### PR DESCRIPTION
Remove the need for remembering the court's on-deck queue position. Adjust game view's click handlers to flip  the card without interfering with the court selection.